### PR TITLE
Code refinements

### DIFF
--- a/include/sushi/ast/expression/command-like.h
+++ b/include/sushi/ast/expression/command-like.h
@@ -39,9 +39,12 @@ struct CommandLike : Expression {
     SUSHI_ACCEPT_VISITOR_FROM(Expression)
     SUSHI_VISITABLE(CommandLikeVisitor)
 
-    CommandLike(std::vector<Redirection> redirs) : redirs(std::move(redirs)) {}
+    CommandLike(
+        std::vector<Redirection> redirs, std::unique_ptr<CommandLike> pipe_next)
+        : redirs(std::move(redirs)), pipe_next(std::move(pipe_next)) {}
 
     std::vector<Redirection> redirs;
+    std::unique_ptr<CommandLike> pipe_next;
 };
 
 struct FunctionCall : CommandLike {
@@ -49,9 +52,9 @@ struct FunctionCall : CommandLike {
 
     FunctionCall(
         Identifier func, std::vector<std::unique_ptr<Expression>> parameters,
-        std::vector<Redirection> redirs)
-        : CommandLike(std::move(redirs)), func(std::move(func)),
-          parameters(std::move(parameters)){};
+        std::vector<Redirection> redirs, std::unique_ptr<CommandLike> pipe_next)
+        : CommandLike(std::move(redirs), std::move(pipe_next)),
+          func(std::move(func)), parameters(std::move(parameters)){};
 
     Identifier func;
     std::vector<std::unique_ptr<Expression>> parameters;
@@ -65,9 +68,9 @@ struct Command : CommandLike {
 
     Command(
         std::string cmd_name, std::vector<CommandParam> parameters,
-        std::vector<Redirection> redirs)
-        : CommandLike(std::move(redirs)), cmd_name(std::move(cmd_name)),
-          parameters(std::move(parameters)) {}
+        std::vector<Redirection> redirs, std::unique_ptr<CommandLike> pipe_next)
+        : CommandLike(std::move(redirs), std::move(pipe_next)),
+          cmd_name(std::move(cmd_name)), parameters(std::move(parameters)) {}
 
     std::string cmd_name;
     std::vector<CommandParam> parameters;

--- a/include/sushi/lexer/token.h
+++ b/include/sushi/lexer/token.h
@@ -1,9 +1,9 @@
 #ifndef SUSHI_LEXER_TOKEN_H_
 #define SUSHI_LEXER_TOKEN_H_
 
+#include "./error.h"
 #include "./token-location.h"
 #include "boost/variant.hpp"
-#include "./error.h"
 #include <string>
 #include <unordered_map>
 
@@ -78,6 +78,7 @@ struct Token {
         kColon,       // :
         kSemicolon,   // ;
         kExclamation, // !
+        kPipe,        // |
         kDollar,      // $
         kLParen,      // (
         kRParen,      // )
@@ -165,6 +166,7 @@ struct Token {
         case Type::kColon: return ":";
         case Type::kSemicolon: return ";";
         case Type::kExclamation: return "!";
+        case Type::kPipe: return "|";
         case Type::kDollar: return "$";
         case Type::kLParen: return "(";
         case Type::kRParen: return ")";
@@ -244,10 +246,11 @@ struct Token {
             {'<', Type::kLAngle},    {'>', Type::kRAngle},
             {',', Type::kComma},     {':', Type::kColon},
             {';', Type::kSemicolon}, {'!', Type::kExclamation},
-            {'$', Type::kDollar},    {'(', Type::kLParen},
-            {')', Type::kRParen},    {'[', Type::kLBracket},
-            {']', Type::kRBracket},  {'{', Type::kLBrace},
-            {'}', Type::kRBrace},    {'=', Type::kSingleEq}};
+            {'|', Type::kPipe},      {'$', Type::kDollar},
+            {'(', Type::kLParen},    {')', Type::kRParen},
+            {'[', Type::kLBracket},  {']', Type::kRBracket},
+            {'{', Type::kLBrace},    {'}', Type::kRBrace},
+            {'=', Type::kSingleEq}};
         return single_punct_map;
     }
 

--- a/include/sushi/scope.h
+++ b/include/sushi/scope.h
@@ -21,7 +21,6 @@ class Scope {
     struct IdentInfo {
         TokenLocation defined_loc;
         Scope *defined_scope;
-        std::unique_ptr<type::Type> type;
         // bool is_const; // not useful currently
     };
 
@@ -84,6 +83,13 @@ class Environment {
         blocks_[block] = scope;
         return true;
     }
+    bool Insert(const ast::Expression *expr, std::unique_ptr<type::Type> t) {
+        if (typings_.count(expr)) {
+            return false;
+        }
+        typings_[expr] = std::move(t);
+        return true;
+    }
     const Scope *LookUp(const ast::Identifier *ident) const {
         auto iter = idents_.find(ident);
         return iter == end(idents_) ? nullptr : iter->second.get();
@@ -92,10 +98,16 @@ class Environment {
         auto iter = blocks_.find(block);
         return iter == end(blocks_) ? nullptr : iter->second.get();
     }
+    const type::Type *LookUp(const ast::Expression *expr) const {
+        auto iter = typings_.find(expr);
+        return iter == end(typings_) ? nullptr : iter->second.get();
+    }
 
   private:
     std::unordered_map<const ast::Identifier *, std::shared_ptr<Scope>> idents_;
     std::unordered_map<const ast::Program *, std::shared_ptr<Scope>> blocks_;
+    std::unordered_map<const ast::Expression *, std::unique_ptr<type::Type>>
+        typings_;
 };
 
 } // namespace sushi

--- a/test/lexer/single-token.cpp
+++ b/test/lexer/single-token.cpp
@@ -39,6 +39,7 @@ TEST(SingleTokenTest, TestPunctuation) {
     NoIndentStrIsToks("(", TK(kLParen));
     NoIndentStrIsToks(")", TK(kRParen));
     NoIndentStrIsToks("!", TK(kExclamation));
+    NoIndentStrIsToks("|", TK(kPipe));
     NoIndentStrIsToks("$", TK(kDollar));
 }
 


### PR DESCRIPTION
- Now the abstraction of `Environment` is a collection of results that generated by previous analysis procedures (type checking, scope generation etc.)
    - Now `Scope` only handles informations of lexical scopes.
    - Add typing informations of `ast::Expression` to `Environment`.
- Add `|`(pipe) token to lexer.
- Add pipe abstraction to `ast::CommandLike`